### PR TITLE
Minor typo fix. Cross-platformn -> Cross-platform

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -190,7 +190,7 @@
           open System
           let cache = new Cache()
 
-      ### Cross-platformn caching
+      ### Cross-platform caching
 
       Say you need a function that caches values in an in-memory dictionary, or using
       a local file system when it is available. Using `#if`, you can write:


### PR DESCRIPTION
On line 193, there is an extra letter appended to Cross-platform. This changes removes the letter "n" from the end of that word.
